### PR TITLE
Fix: RX Stall may occur locking the system

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,7 +334,10 @@ where
 
     fn wait_idle(&mut self) {
         self.tx.clear_stalled_flag();
-        while (!self.tx.has_stalled() || !self.tx.is_empty()) && !self.has_errored() {}
+        while (!self.tx.has_stalled() || !self.tx.is_empty()) && !self.has_errored() {
+            // discard rx fifo to a prevent RX stall
+            let _ = self.rx.read();
+        }
     }
 
     fn resume_after_error(&mut self) {


### PR DESCRIPTION
A the end of a writing operation with large amount of data, the tx fifo may get filled and then process enters the wait_idle method.

However, while the TX fifo gets emptied, the RX fifo gets filled and it may cause an RX stall, effectively stopping the state machine, and preventing the idle condition from ever raising.