### PR TITLE
Add basic GitHub CI workflow config

### DIFF
--- a/.github/workflows/basic_ci.yml
+++ b/.github/workflows/basic_ci.yml
@@ -1,0 +1,47 @@
+name: Basic CI
+
+on: [push, pull_request]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: build
+    strategy:
+      matrix:
+        features: ["", "--features eh1_0_alpha"]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+          profile: minimal
+          override: true
+      - run: cargo install flip-link
+      - run: cargo build --all
+      - run: cargo build --all --release
+
+  lint:
+    name: lint
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - run: cargo clippy -- -Dwarnings
+
+  format:
+    name: format
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - run: cargo fmt -- --check


### PR DESCRIPTION
Builds from the current tip of the `main` branch (https://github.com/rp-rs/i2c-pio-rs/commit/1a66fa53857dceb8e9ab1dc5be4fdda1b39107d4) are failing.

This PR adds a basic GitHub CI workflow to allow detecting such build failures.