### PR TITLE
Update dependency on rp2040-hal to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i2c-pio"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "I2C driver implementation using the RP2040's PIO peripheral."
@@ -16,7 +16,7 @@ embedded-hal = "0.2.6"
 nb = "1.0.0"
 pio = "0.2.0"
 pio-proc = "0.2.0"
-rp2040-hal = "0.6.0"
+rp2040-hal = "0.7.0"
 fugit = "0.3.5"
 defmt = { version = "0.3.0", optional = true }
 


### PR DESCRIPTION
Also bump crate version to 0.5.0, because changing the HAL version is a breaking change.