### PR TITLE
Update github runner image to ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build and Test check
 jobs:
   builds:
     name: Build checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         mode: ["", "--release"]


### PR DESCRIPTION
20.04 is no longer supported, see https://github.com/actions/runner-images/issues/11101